### PR TITLE
Use upstream ruamel.yaml instead of ruamel_yaml

### DIFF
--- a/doc/VariantCallingBenchmarkExample.rst
+++ b/doc/VariantCallingBenchmarkExample.rst
@@ -16,7 +16,7 @@ We start by creating a conda environment and installing daisy::
     conda create -y -n daisy python=3.6 matplotlib
     pip install cgatcore
     pip install cgat-daisy
-    conda install ruamel_yaml pysam
+    conda install ruamel.yaml pysam
 
 .. note::
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,7 +2,7 @@ cgatcore
 pandas
 sqlalchemy
 ruffus
-ruamel_yaml
+ruamel.yaml
 pytest
 pysam
 sphinxcontrib-programoutput

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cgatcore
 pandas
 sqlalchemy
 ruffus
-ruamel_yaml
+ruamel.yaml
 pytest
 pysam
 tqdm

--- a/src/daisy/tasks/__init__.py
+++ b/src/daisy/tasks/__init__.py
@@ -5,14 +5,9 @@ import os
 import glob
 import importlib
 import importlib.util
-# bioconda: ruamel.yml
-# defaults: ruamel_yaml
-try:
-    import ruamel_yaml as yaml
-    from ruamel_yaml import RoundTripLoader
-except ImportError:
-    from ruamel import yaml
-    from ruamel.yaml import RoundTripLoader
+
+from ruamel import yaml
+from ruamel.yaml import RoundTripLoader
 
 import cgatcore.iotools as IOTools
 import daisy.toolkit

--- a/src/daisy/tasks/__init__.py
+++ b/src/daisy/tasks/__init__.py
@@ -6,8 +6,7 @@ import glob
 import importlib
 import importlib.util
 
-from ruamel import yaml
-from ruamel.yaml import RoundTripLoader
+from ruamel.yaml import YAML
 
 import cgatcore.iotools as IOTools
 import daisy.toolkit
@@ -26,7 +25,7 @@ def get_default_params():
     defaults = os.path.join(os.path.dirname(__file__), "defaults.yml")
     if os.path.exists(defaults):
         with IOTools.open_file(defaults) as inf:
-            result = yaml.load(inf, Loader=RoundTripLoader)
+            result = YAML(typ="rt").load(inf)
     else:
         result = {}
     return result


### PR DESCRIPTION
Hi @AndreasHeger,

I'm currently looking at what packages on conda-forge and Bioconda have a dependency on the non-maintained `ruamel_yaml` package.

It'd be good if we could have this package depend on `ruamel.yaml` instead of `ruamel_yaml`, too.

NB: The latest `conda-forge::ruamel_yaml` is still at version `0.15.80` -- upstream released that version 5 years ago.

Conda-forge will stop (re-)building (the severly outdated) `ruamel_yaml` package;
tracking issue: https://github.com/conda-forge/ruamel_yaml-feedstock/issues/107

----
This should also add compatibility for ruamel.yaml=0.18.
ruamel.yaml=0.18 removed the top-level load, dump, etc. functions.
For details see https://pypi.org/project/ruamel.yaml/0.18.4/ .

----
Cheers,

Marcel